### PR TITLE
Reduce n_bins in data properties example to speed-up docs build time

### DIFF
--- a/notebooks/data_properties.ipynb
+++ b/notebooks/data_properties.ipynb
@@ -245,12 +245,13 @@
    "source": [
     "%%time\n",
     "\n",
+    "df_chiller = discretized_sample_dataset(\"chiller\", n_bins=10)\n",
     "try:\n",
-    "    assert_mdp(discretized_sample_dataset(\"chiller\"), lags=lags)\n",
+    "    assert_mdp(df_chiller, lags=lags)\n",
     "except NotMDPDataError as e:\n",
     "    print(\"Continue this example despite MDP check errors:\\n\", e)\n",
     "\n",
-    "plot_information(discretized_sample_dataset(\"chiller\"), lags=lags);"
+    "plot_information(df_chiller, lags=lags);"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* speed-up docs build (aka `jupyter execute notebooks/data_properties.ipynb`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
