### PR TITLE
Fix warning silencer crashes when receiving DeprecationWarning objects

### DIFF
--- a/src/a2rl/__init__.py
+++ b/src/a2rl/__init__.py
@@ -26,12 +26,13 @@ def _warn(message, category=None, stacklevel=1, source=None):
     if category is not DeprecationWarning:
         original_warn(message, category, stacklevel, source)
 
-    if message.startswith("distutils Version classes are deprecated."):
-        # https://github.com/mwaskom/seaborn/issues/2724
-        return
-    if message.endswith("descriptors from generated code or query the descriptor_pool."):
-        # https://github.com/tensorflow/tensorboard/issues/5798
-        return
+    if isinstance(message, str):
+        if message.startswith("distutils Version classes are deprecated."):
+            # https://github.com/mwaskom/seaborn/issues/2724
+            return
+        if message.endswith("descriptors from generated code or query the descriptor_pool."):
+            # https://github.com/tensorflow/tensorboard/issues/5798
+            return
 
     # Still show any other deprecation warning.
     original_warn(message, category, stacklevel, source)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*  unbreak some cases where `_warn()` receives non-string objects such as `DeprecationWarning` objects.

*Testing done:* done

## Merge Checklist

*Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're
unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of
what we are going to look for before merging your pull request.*

- [x] I have read the [CONTRIBUTING](https://github.com/awslabs/amazon-accessible-rl-sdk/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I have updated any necessary documentation, including [README](https://github.com/awslabs/amazon-accessible-rl-sdk/blob/main/README.md) and [docs](https://github.com/awslabs/amazon-accessible-rl-sdk/tree/main/docs) (if appropriate).

By submitting this pull request, I confirm that my contribution is made under the terms of the
Apache 2.0 license.
